### PR TITLE
fix: Enable dirs feature in rattler-networking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,7 +2668,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pixi-install-to-prefix"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3274,6 +3274,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http-client",
  "base64",
+ "dirs",
  "fs-err",
  "getrandom 0.4.2",
  "http 1.4.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixi-install-to-prefix"
 description = "Install pixi environments to an arbitrary prefix"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 
 # See https://doc.rust-lang.org/cargo/reference/profiles.html
@@ -39,6 +39,7 @@ rattler_conda_types = "0.46.1"
 rattler_config = { version = "0.3.12" }
 rattler_lock = "0.30.0"
 rattler_networking = { version = "0.26.12", default-features = false, features = [
+  "dirs",
   "rattler_config",
   "s3",
 ] }


### PR DESCRIPTION
# Motivation

otherwise you get a 401 when pulling private packages because then pixi-install-to-prefix won't read your system's credentials that were generated with `pixi auth login`

# Changes

<!-- What changes have been performed? -->
