### PR TITLE
feat: add --version flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,7 +2775,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pixi-install-to-prefix"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pixi-install-to-prefix"
 description = "Install pixi environments to an arbitrary prefix"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2024"
 
 # See https://doc.rust-lang.org/cargo/reference/profiles.html

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use tokio::fs::{self, OpenOptions};
 /* -------------------------------------------- CLI -------------------------------------------- */
 
 #[derive(Parser, Debug)]
+#[command(version)]
 struct Cli {
     /// The path to the prefix where you want to install the environment.
     #[clap()]


### PR DESCRIPTION
Adds a `--version` flag to the CLI via clap's `#[command(version)]` attribute, which reports the version from `Cargo.toml`.

```
$ pixi-install-to-prefix --version
pixi-install-to-prefix 0.1.5
```